### PR TITLE
Remove event listeners on cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,19 +28,27 @@ const InternetStatus = ({
     }
   };
 
-  window.addEventListener("offline", () => {
+  const handleOnline = () => {
+    startSpeedTest();
+  };
+
+  const handleOffline = () => {
     setNetworkStatus("🔴");
     window.clearInterval(window.setIntervalId);
     window.setIntervalId = null;
-  });
+  };
 
-  window.addEventListener("online", () => {
-    startSpeedTest();
-  });
+  window.addEventListener("offline", handleOffline);
+
+  window.addEventListener("online", handleOnline);
 
   useEffect(() => {
     startSpeedTest();
-    return () => window.clearInterval(window.setIntervalId);
+    return () => {
+      window.clearInterval(window.setIntervalId);
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
   }, []);
 
   return <div>{networkStatus}</div>;


### PR DESCRIPTION
Hi @Srivatsa-Rao . Thanks for the useful library! 😉  😜 

In this PR, I remove the `online` and `offline` event listeners on the effect cleanup to prevent memory leaks when the component un-mounts.

Hope you accept the PR and publish my fix. 